### PR TITLE
Modified fxc.exe search function.

### DIFF
--- a/fips-generators/util/hlslcompiler.py
+++ b/fips-generators/util/hlslcompiler.py
@@ -22,7 +22,8 @@ def findFxc() :
     Returns an unicode path string of fxc.exe if found, or None if
     not found.
     '''
-    fcxPath = None;
+    fxcPath = None;
+    fxcSubPath = u'bin\\x86\\fxc.exe'
 
     # first get the preferred kit name (either 8.1 or 10, are there others?)
     try :
@@ -30,24 +31,23 @@ def findFxc() :
             for kit in ['KitsRoot10', 'KitsRoot81'] :
                 try :
                     fxcPath, _ = _winreg.QueryValueEx(key, kit)
-                    break
+                    fxcPath += fxcSubPath
+                    if os.path.isfile(fxcPath) :
+                        return fxcPath
                 except :
                     fxcPath = None
 
         # if registry is not found, try a few other likely paths
         for path in [
-           'C:\\Program Files (x86)\\Windows Kits\\8.1\\',
-           'C:\\Program Files (x86)\\Windows Kits\\10.0\\'
+           'C:\\Program Files (x86)\\Windows Kits\\10\\',
+           'C:\\Program Files (x86)\\Windows Kits\\8.1\\'
         ] :
             if os.path.isdir(path) :
-                fxcPath = path
-                break
+                fxcPath = path + fxcSubPath
+                if os.path.isfile(fxcPath) :
+                    return fxcPath
 
-        fxcPath += u'bin\\x86\\fxc.exe'
-        if os.path.isfile(fxcPath) :
-            return fxcPath
-        else :
-            return None
+        return None
 
     except WindowsError :
         return None


### PR DESCRIPTION
Tried to build Oryol samples with new VS2015 installation, which didn't locate fxc.exe.

At first my outdated revision of Oryol didn't work because it searched for registry keys ['KitsRoot10', 'KitsRoot81'], and stopped at the first key found - but my '10' folder does not contain a fxc.exe, only my '8.1' folder does. A possible fix would have been to check for existence of 'bin\x86\fxc.exe' inside the loop, and only break if one is found.

Now, the current revision of this function never fails - by chance - in my situation because:

There's no conditional check before the second search (the 'likely paths'), so the registry search is kind of superfluous.
Again it checks for existence of the path only, just in reverse order - 8.1 is searched first.
For a brief test I reversed the path search order. This didn't fail as expected because the path on my system is '..\10\', not '..\10.0\'.