### PR TITLE
Minor compile fix for VS Warning C4819

### DIFF
--- a/code/Modules/TBUI/TBUISetup.h
+++ b/code/Modules/TBUI/TBUISetup.h
@@ -25,7 +25,7 @@ public:
     /// default font size
     int32 DefaultFontSize = 14;
     /// initial glyph set to prevent excessive reconstruction of font texture
-    StringAtom GlyphSet = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~•·";
+	StringAtom GlyphSet = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\xE2\x80\xA2\xC2\xB7";
 
     /// resource pool size
     int32 ResourcePoolSize = 256;


### PR DESCRIPTION
Some Unicode characters in ANSI source file will cause C4819 on  a system with a codepage that cannot represent all characters in the file. like Chinese (CP936).