### PR TITLE
pinned revision for glfw - because latest version is broken.

### DIFF
--- a/fips.yml
+++ b/fips.yml
@@ -13,6 +13,7 @@ imports:
         git: https://github.com/floooh/fips-zlib.git
     fips-glfw:
         git: https://github.com/floooh/fips-glfw.git
+        rev: 62319ab9
     fips-libcurl:
         git: https://github.com/floooh/fips-libcurl.git
     fips-remotery:


### PR DESCRIPTION
![bildschirmfoto von 2016-03-17 13-49-02](https://cloud.githubusercontent.com/assets/577713/13846428/41ca2d6a-ec47-11e5-9082-feb3252c1068.png)
fips-glfw is current broken - the viewport doesn't update when you resize the window.

(pinning version in oryol would make a lot of sense for those that are using oryol btw)
