### PR TITLE
Stringbuilder::substituteCommon can fail when buffer grows

### DIFF
--- a/code/Modules/Core/String/StringBuilder.cc
+++ b/code/Modules/Core/String/StringBuilder.cc
@@ -314,7 +314,10 @@ void
 StringBuilder::substituteCommon(char* occur, int matchLen, int substLen, const char* subst) {
     const int diff = substLen - matchLen;
     if (diff > 0) {
+        // Preserve occur if buffer is reallocated by ensureRoom
+        size_t offs = occur - this->buffer;
         this->ensureRoom(diff);
+        occur = this->buffer + offs;
     }
     
     // move tail in or out


### PR DESCRIPTION
If ensureRoom needs to grow the stringbuilder buffer, the 'occur' param in substituteCommon may be invalidated. This preserves the param across reallocation.

Note: This was failing for me when using a rather long path for the local filesystem.