### PR TITLE
CHG: glsl source static additions to avoid multiple symbols

### DIFF
--- a/fips-generators/Shader.py
+++ b/fips-generators/Shader.py
@@ -1658,16 +1658,19 @@ def writeProgramHeader(f, shdLib, program) :
         f.write('        };\n')
         f.write('        #pragma pack(pop)\n')
     f.write('        static ShaderSetup Setup();\n')
+
+    writeTextureBlocksHeader(f, shdLib)
+
     f.write('    };\n')
 
 #-------------------------------------------------------------------------------
 def writeTextureBlocksHeader(f, shdLib) :
     # write texture bind slot constants
     for tb in shdLib.textureBlocks.values() :
-        f.write('    struct {} {{\n'.format(tb.bindName))
+        f.write('        struct {} {{\n'.format(tb.bindName))
         for tex in tb.textures :
-            f.write('        static const int {} = {};\n'.format(tex.bindName, tex.bindSlot))
-        f.write('    };\n')
+            f.write('            static const int {} = {};\n'.format(tex.bindName, tex.bindSlot))
+        f.write('       };\n')
 
 #-------------------------------------------------------------------------------
 def generateHeader(absHeaderPath, shdLib) :
@@ -1675,7 +1678,7 @@ def generateHeader(absHeaderPath, shdLib) :
     writeHeaderTop(f, shdLib)
     for prog in shdLib.programs.values() :
         writeProgramHeader(f, shdLib, prog)
-    writeTextureBlocksHeader(f, shdLib)
+    #writeTextureBlocksHeader(f, shdLib)
     writeHeaderBottom(f, shdLib)
     f.close()
 
@@ -1706,7 +1709,7 @@ def writeShaderSource(f, absPath, shdLib, shd, slVersion) :
     if isGLSL[slVersion] :
         # GLSL source code is directly inlined for runtime-compilation
         f.write('#if ORYOL_OPENGL\n')
-        f.write('const char* {}_{}_src = \n'.format(shd.name, slVersion))
+        f.write('static const char* {}_{}_src = \n'.format(shd.name, slVersion))
         for line in shd.generatedSource[slVersion] :
             f.write('"{}\\n"\n'.format(line.content))
         f.write(';\n')


### PR DESCRIPTION
CHG: texture structure is now inside the class definition rather than the oryol namespace to avoid nameclashes