### PR TITLE
Use resource bundle path for root: on MacOS and iOS

### DIFF
--- a/code/Modules/LocalFS/LocalFileSystem.cc
+++ b/code/Modules/LocalFS/LocalFileSystem.cc
@@ -18,7 +18,7 @@ LocalFileSystem::init(const StringAtom& scheme_) {
     StringBuilder strBuilder;
 
     // setup the root assign
-    strBuilder.Format(4096, "%s:///%s", this->scheme.AsCStr(), fsWrapper::getExecutableDir().AsCStr());
+    strBuilder.Format(4096, "%s:///%s", this->scheme.AsCStr(), fsWrapper::getRootDir().AsCStr());
     IO::SetAssign("root:", strBuilder.GetString());
 
     // setup the cwd assign

--- a/code/Modules/LocalFS/posix/posixFSWrapper.h
+++ b/code/Modules/LocalFS/posix/posixFSWrapper.h
@@ -33,8 +33,8 @@ public:
     /// close file
     static void close(handle f);
     
-    /// get path to own executable
-    static String getExecutableDir();
+    /// get path to where application resources are typically stored
+    static String getRootDir();
     /// get current directory
     static String getCwd();
 };


### PR DESCRIPTION
This is my local fix for Issue#249, for the resource path on MacOS and iOS. This resolves root: to ${MainBundle}/Contents/Resources on MacOS, and ${MainBundle} on iOS as suggested here: https://developer.apple.com/library/content/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html#//apple_ref/doc/uid/10000123i-CH101-SW1

Thanks!