### PR TITLE
Fix Android build.

### DIFF
--- a/code/Modules/Core/Main.h
+++ b/code/Modules/Core/Main.h
@@ -40,7 +40,7 @@ Oryol::Args OryolArgs; \
 void android_main(struct android_app* app_) { \
     app_dummy(); \
     OryolAndroidAppState = app_; \
-    clazz* app = Memory::New<clazz>(); \
+    clazz* app = Oryol::Memory::New<clazz>(); \
     app->StartMainLoop(); \
     Oryol::Memory::Delete<clazz>(app); \
 }


### PR DESCRIPTION
Building Android Oryol app was giving this error.

```
In file included from /home/kkim/fips-projects/m19g/src/TestApp.cc:3:0:
/home/kkim/fips-projects/m19g/src/TestApp.cc: In function 'void android_main(android_app*)':
/home/kkim/fips-projects/oryol/code/Modules/Core/Main.h:43:18: error: 'Memory' has not been declared
     clazz* app = Memory::New<clazz>(); \
                  ^
/home/kkim/fips-projects/m19g/src/TestApp.cc:10:1: note: in expansion of macro 'OryolMain'
 OryolMain(GameApp);
 ^
/home/kkim/fips-projects/oryol/code/Modules/Core/Main.h:43:35: error: expected primary-expression before '>' token
     clazz* app = Memory::New<clazz>(); \
                                   ^
/home/kkim/fips-projects/m19g/src/TestApp.cc:10:1: note: in expansion of macro 'OryolMain'
 OryolMain(GameApp);
 ^
/home/kkim/fips-projects/oryol/code/Modules/Core/Main.h:43:37: error: expected primary-expression before ')' token
     clazz* app = Memory::New<clazz>(); \
                                     ^
/home/kkim/fips-projects/m19g/src/TestApp.cc:10:1: note: in expansion of macro 'OryolMain'
 OryolMain(GameApp);
 ^
CMakeFiles/TestApp.dir/build.make:62: recipe for target 'CMakeFiles/TestApp.dir/src/TestApp.cc.o' failed
make[2]: *** [CMakeFiles/TestApp.dir/src/TestApp.cc.o] Error 1
CMakeFiles/Makefile2:69: recipe for target 'CMakeFiles/TestApp.dir/all' failed
make[1]: *** [CMakeFiles/TestApp.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```