### PR TITLE
modify OryolMain for console application.

### DIFF
--- a/code/Modules/Core/Main.h
+++ b/code/Modules/Core/Main.h
@@ -32,7 +32,15 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE prevInstance, LPSTR lpCmdLine,
     app->StartMainLoop(); \
     Oryol::Memory::Delete<clazz>(app); \
     return 0; \
-}
+} \
+/********for vs console app********/ \
+int main(int argc, const char** argv) { \
+    OryolArgs = Oryol::Args(argc, argv); \
+    clazz* app = Oryol::Memory::New<clazz>(); \
+    app->StartMainLoop(); \
+    Oryol::Memory::Delete(app); \
+    return 0; \
+} \
 #elif ORYOL_ANDROID
 #define OryolMain(clazz) \
 android_app* OryolAndroidAppState = nullptr; \


### PR DESCRIPTION
When using fips and Oryol,  set app type cmdline, the OryolMain method only generate WinMain, which not suitable to cmdline app, and leads to no main error.
I simply add a int main(int argc, char *argv[]) method, because I don't find a method to distinguish Windowed app and console app. Maybe we can add a macro define in fips build system.