### PR TITLE
Use move assignment in elementBuffer::insert(int, TYPE&&)

### DIFF
--- a/code/Modules/Core/Containers/elementBuffer.h
+++ b/code/Modules/Core/Containers/elementBuffer.h
@@ -633,7 +633,7 @@ elementBuffer<TYPE>::insert(int index, TYPE&& elm) {
     bool slotConstructed = true;
     TYPE* ptr = this->prepareInsert(index, slotConstructed);
     if (slotConstructed) {
-        *ptr = elm;
+        *ptr = std::move(elm);
     }
     else {
         new(ptr) TYPE(std::move(elm));


### PR DESCRIPTION
I was using an `Oryol::Map` to store `std::unique_ptr` values, and it wouldn't compile because the `elementBuffer` was trying to copy the value instead of moving it.  I think this is the right change to make, does it look correct to you?  The C++ move rules can be a bit confusing 😁