### PR TITLE
Gamepad mapping for Wii U Pro Controller on Linux

### DIFF
--- a/code/Modules/Input/private/glfw/glfwInputMgr.cc
+++ b/code/Modules/Input/private/glfw/glfwInputMgr.cc
@@ -179,6 +179,39 @@ glfwInputMgr::setupGamepadMappings() {
     m.Axes[GamepadAxis::RightTrigger].Scale = 0.5f;
     m.Axes[GamepadAxis::RightTrigger].Bias = 0.5f;
     this->addGamepadMapping("Sony Computer Entertainment Wireless Controller", m);
+    
+    // Nintendo Wii U Pro Controller, Linux
+    // Note: A/B/X/Y buttons intentionally map to the physical location of the equivalent named
+    //       buttons on an Xbox360 controller - NOT the button labels on the Wii U controller.
+    m = GamepadMapping();
+    m.Buttons[GamepadButton::A] = 0;
+    m.Buttons[GamepadButton::B] = 1;
+    m.Buttons[GamepadButton::X] = 3;
+    m.Buttons[GamepadButton::Y] = 2;
+    m.Buttons[GamepadButton::LeftBumper] = 4;
+    m.Buttons[GamepadButton::RightBumper] = 5;
+    m.Buttons[GamepadButton::LeftTrigger] = 6;
+    m.Buttons[GamepadButton::RightTrigger] = 7;
+    m.Buttons[GamepadButton::Back] = 8;
+    m.Buttons[GamepadButton::Start] = 9;
+    m.Buttons[GamepadButton::LeftStick] = 11;
+    m.Buttons[GamepadButton::RightStick] = 12;
+    m.Buttons[GamepadButton::DPadUp] = 13;
+    m.Buttons[GamepadButton::DPadDown] = 14;
+    m.Buttons[GamepadButton::DPadLeft] = 15;
+    m.Buttons[GamepadButton::DPadRight] = 16;
+    m.Buttons[GamepadButton::Center] = 10;
+    m.Axes[GamepadAxis::LeftStickHori].Axis = 0;
+    m.Axes[GamepadAxis::LeftStickVert].Axis = 1;
+    m.Axes[GamepadAxis::RightStickHori].Axis = 2;
+    m.Axes[GamepadAxis::RightStickVert].Axis = 3;
+    m.Axes[GamepadAxis::LeftTrigger].Axis = 4;
+    m.Axes[GamepadAxis::LeftTrigger].Scale = 0.5f;
+    m.Axes[GamepadAxis::LeftTrigger].Bias = 0.5f;
+    m.Axes[GamepadAxis::RightTrigger].Axis = 5;
+    m.Axes[GamepadAxis::RightTrigger].Scale = 0.5f;
+    m.Axes[GamepadAxis::RightTrigger].Bias = 0.5f;
+    this->addGamepadMapping("Nintendo Wii Remote Pro Controller", m);
     #elif ORYOL_WINDOWS
     // Xbox360 controller is the default mapping
     // FIXME: triggers are only exposed as axes 


### PR DESCRIPTION
Added gamepad mapping for Nintendo Wii U Pro Controller on glfw Linux.