### PR TITLE
Remove redefinition of ASENSOR_TYPE_GAME_ROTATION_VECTOR

### DIFF
--- a/code/Modules/Core/private/android/androidBridge.h
+++ b/code/Modules/Core/private/android/androidBridge.h
@@ -11,11 +11,6 @@
 
 struct android_app;
 
-// undocumented sensor type (not documented in NDK)
-enum {
-    ASENSOR_TYPE_GAME_ROTATION_VECTOR = 15,
-};
-
 namespace Oryol {
 class App;
 


### PR DESCRIPTION
After updating to the latest version of the Android NDK using 'fips setup android' received error when building:

/oryol/code/Modules\Core/private/android/androidBridge.h:16:5: error: redefinition of enumerator 'ASENSOR_TYPE_GAME_ROTATION_VECTOR'
    ASENSOR_TYPE_GAME_ROTATION_VECTOR = 15,
    ^
/fips-sdks/android/ndk-bundle/sysroot/usr/include\android/sensor.h:169:5: note: previous definition is here
    ASENSOR_TYPE_GAME_ROTATION_VECTOR = 15,
    ^

The enum is now documented and included in the latest version of the NDK: https://developer.android.com/ndk/reference/group/sensor