### PR TITLE
Demangle C++ function names in stack trace

### DIFF
--- a/code/Modules/Core/StackTrace.cc
+++ b/code/Modules/Core/StackTrace.cc
@@ -74,21 +74,21 @@ StackTrace::Dump(char* buf, int bufSize) {
     char* dstPtr = buf;
     const char* dstEndPtr = buf + bufSize;
     for (unsigned int i = 0; i < numFrames; i++) {
-		StringBuilder s = symbols[i];
-		int first_part = s.FindFirstOf(0, EndOfString, "(");
-		int mangled = s.FindFirstOf(first_part, EndOfString, "+");
-		int status;
-		char *demangled_symbol = abi::__cxa_demangle(s.GetSubString(first_part + 1, mangled).AsCStr(), NULL, NULL, &status);
-		StringBuilder demangled = s.GetSubString(0, first_part);
-		demangled.Append(": ");
-		demangled.Append(demangled_symbol);
-		demangled.Append(s.GetSubString(s.FindFirstOf(first_part, EndOfString, ")") + 1, EndOfString));
-		if (status == 0) {
-			dstPtr = appendString((char*)demangled.GetString().AsCStr(), dstPtr, dstEndPtr, true);
-		}
-		else {
-			dstPtr = appendString(symbols[i], dstPtr, dstEndPtr, true);
-		}
+        StringBuilder s = symbols[i];
+        int first_part = s.FindFirstOf(0, EndOfString, "(");
+        int mangled = s.FindFirstOf(first_part, EndOfString, "+");
+        int status;
+        char *demangled_symbol = abi::__cxa_demangle(s.GetSubString(first_part + 1, mangled).AsCStr(), NULL, NULL, &status);
+        StringBuilder demangled = s.GetSubString(0, first_part);
+        demangled.Append(": ");
+        demangled.Append(demangled_symbol);
+        demangled.Append(s.GetSubString(s.FindFirstOf(first_part, EndOfString, ")") + 1, EndOfString));
+        if (status == 0) {
+            dstPtr = appendString((char*)demangled.GetString().AsCStr(), dstPtr, dstEndPtr, true);
+        }
+        else {
+            dstPtr = appendString(symbols[i], dstPtr, dstEndPtr, true);
+        }
     }
     std::free(symbols);
 }

--- a/code/Modules/Core/StackTrace.cc
+++ b/code/Modules/Core/StackTrace.cc
@@ -14,6 +14,7 @@
 #include "Pre.h"
 #include "StackTrace.h"
 #if HAVE_BACKTRACE
+#include <cxxabi.h>
 #include <execinfo.h>
 #include "String/StringBuilder.h"
 #endif
@@ -23,8 +24,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
-
-#include <cxxabi.h>
 
 /*
     NOTE: The code in StackTrace might be called from signal handlers,


### PR DESCRIPTION
This improves stack traces.

An example stack trace:

```*** ORYOL ASSERT: false
  msg=none
  file=/home/noam/Development/Zany80/Lua/src/main.cpp
  line=110
  func=virtual Oryol::AppState::Code Zany80::OnRunning()
  callstack:
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80: Oryol::StackTrace::Dump(char*, int) [0x5590f035451b]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80: Oryol::Log::AssertMsg(char const*, char const*, char const*, int, char const*) [0x5590f034fe98]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80: Zany80::OnRunning() [0x5590f0271cb6]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80: Oryol::App::onFrame() [0x5590f034d0c1]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80: Oryol::App::StartMainLoop() [0x5590f034ce39]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80(main+0x6a) [0x5590f02711ea]
/lib64/libc.so.6(__libc_start_main+0xea) [0x7f35e2e0caca]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80(_start+0x2a) [0x5590f0264a1a]
```

Before, that would have been this:
```*** ORYOL ASSERT: false
  msg=none
  file=/home/noam/Development/Zany80/Lua/src/main.cpp
  line=110
  func=virtual Oryol::AppState::Code Zany80::OnRunning()
  callstack:
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80(_ZN5Oryol10StackTrace4DumpEPci+0x45) [0x55b5acdc64cb]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80(_ZN5Oryol3Log9AssertMsgEPKcS2_S2_iS2_+0x76) [0x55b5acdc1e48]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80(_ZN6Zany809OnRunningEv+0x180) [0x55b5acce3c66]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80(_ZN5Oryol3App7onFrameEv+0x17f) [0x55b5acdbf071]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80(_ZN5Oryol3App13StartMainLoopEv+0x7d) [0x55b5acdbede9]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80(main+0x6a) [0x55b5acce319a]
/lib64/libc.so.6(__libc_start_main+0xea) [0x7ff7790b7aca]
/home/noam/Development/Zany80/Lua/build/fips-deploy/Lua/linux-make-debug/zany80(_start+0x2a) [0x55b5accd69ca]
```