### PR TITLE
std::function return value for OryolClassCreator

### DIFF
--- a/code/Modules/Core/Creator.h
+++ b/code/Modules/Core/Creator.h
@@ -11,7 +11,7 @@
 #include "Core/Ptr.h"
 #include <functional>
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7 || (__GNUC__ == 7 && __GNUC_MINOR__ < 4) || (__GNUC__ == 8 && __GNUC_MINOR__ <1))
 /** WORKAROUND for GCC bug 'lambda argument pack' **/
 #define OryolClassCreator(TYPE) \
 public:\

--- a/code/Modules/Core/Creator.h
+++ b/code/Modules/Core/Creator.h
@@ -15,13 +15,13 @@
 /** WORKAROUND for GCC bug 'lambda argument pack' **/
 #define OryolClassCreator(TYPE) \
 public:\
-static std::function<Ptr<TYPE>()> Creator() {\
+static Ptr<TYPE>(*Creator())() {\
     return [] { return Create(); };\
 };
 #else
 #define OryolClassCreator(TYPE) \
 public:\
-template<typename... ARGS> static std::function<Ptr<TYPE>()> Creator(ARGS... args) {\
+template<typename... ARGS> static Ptr<TYPE>(*Creator(ARGS... args))() {\
   return [args...] { return Create(args...); };\
 };
 #endif


### PR DESCRIPTION
Far from perfect, but it should increase support for using arguments in the creator.

I tried using e.g. std::bind as a better workaround as well, without success.