### PR TITLE
Fix: explicitly set nativeHandles to false during glFactory::initTexture

### DIFF
--- a/code/Modules/Gfx/private/gl/glFactory.cc
+++ b/code/Modules/Gfx/private/gl/glFactory.cc
@@ -214,6 +214,8 @@ glFactory::initTexture(texture& tex, const void* data, int size) {
         tex.glTextures[1] = (GLuint) tex.Setup.NativeHandle[1];
     }
     else {
+        tex.nativeHandles = false;
+
         // create GL texture objects
         const GLenum glTexImageFormat = glTypes::asGLTexImageFormat(setup.ColorFormat);
         const bool isCompressed = PixelFormat::IsCompressedFormat(setup.ColorFormat);


### PR DESCRIPTION
explicitly set nativeHandles to false during glFactory::initTexture, as the nativeHandles could be set to true by the previous texture taking the slot.