### PR TITLE
Fix gl: disable enabled glAttrs during invalidateMeshState()

### DIFF
--- a/code/Modules/Gfx/private/gl/glRenderer.cc
+++ b/code/Modules/Gfx/private/gl/glRenderer.cc
@@ -839,6 +839,12 @@ glRenderer::invalidateMeshState() {
     this->vertexBuffer = 0;
     this->indexBuffer = 0;
     for (int i = 0; i < VertexAttr::NumVertexAttrs; i++) {
+        auto& attr = this->glAttrs[i];
+        if (attr.enabled) {
+            ::glDisableVertexAttribArray(attr.index);
+            ORYOL_GL_CHECK_ERROR();
+        }
+        
         this->glAttrs[i] = pipeline::vertexAttr();
         this->glAttrVBs[i] = 0;
     }


### PR DESCRIPTION
enabled glAttrs should be disabled before it is set to false. otherwise, it may cause opengl errors during the next draw.