### PR TITLE
Fix under latest glm

### DIFF
--- a/code/Modules/Input/Input.h
+++ b/code/Modules/Input/Input.h
@@ -13,6 +13,7 @@
     to query touch gestures.
 */
 #include "Input/InputTypes.h"
+#include "glm/vec3.hpp"
 
 namespace Oryol {
     


### PR DESCRIPTION
I updated glm under fips-glm manually (to avoid a bunch of annoying compiler warnings), and found that a header that was being indirectly included no longer is. This fixes building with the stable branch of glm.