### PR TITLE
emscripten: fix for target HTML element id for the resize callback.

### DIFF
--- a/code/Modules/Gfx/private/emsc/emscDisplayMgr.cc
+++ b/code/Modules/Gfx/private/emsc/emscDisplayMgr.cc
@@ -90,7 +90,7 @@ emscDisplayMgr::SetupDisplay(const GfxSetup& renderSetup, const gfxPointers& ptr
                 this->displayAttrs.FramebufferHeight);
         }
         emscripten_set_canvas_element_size(renderSetup.HtmlElement.AsCStr(), this->displayAttrs.FramebufferWidth, this->displayAttrs.FramebufferHeight);
-        emscripten_set_resize_callback(nullptr, nullptr, false, emscWindowSizeChanged); 
+        emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, nullptr, false, emscWindowSizeChanged); 
     } else if (renderSetup.Windowed) {
         emscripten_set_canvas_element_size(renderSetup.HtmlElement.AsCStr(), renderSetup.Width, renderSetup.Height);
     }


### PR DESCRIPTION
Use EMSCRIPTEN_EVENT_TARGET_WINDOW instead of NULL as target parameter for resize callback after moving to latest Emscripten version.